### PR TITLE
Maintain N values for calculating tail latency. 

### DIFF
--- a/core/modules/nfv_monitor.cc
+++ b/core/modules/nfv_monitor.cc
@@ -13,6 +13,7 @@
 #define DEFAULT_PER_CORE_MIGRATION_PERIOD_US 200000000 // 200 ms
 #define DEFAULT_ACTIVE_FLOW_WINDOW_NS 2000000000 // 2000 ms
 #define DEFAULT_PACKET_COUNT_THRESH 1000000
+#define DEFAULT_LATENCY_QUEUE_SIZE 10000
 
 namespace {
 
@@ -57,6 +58,7 @@ CommandResponse NFVMonitor::Init([[maybe_unused]]const bess::pb::NFVMonitorArg &
   }
   LOG(INFO) << "Traffic update period: " << update_traffic_stats_period_ns_;
 
+  per_core_latency_sample_.set_capacity((arg.latency_sample_size()>0)? arg.latency_sample_size():DEFAULT_LATENCY_QUEUE_SIZE);
   per_core_packet_counter_ = 0;
 
   return CommandSuccess();
@@ -68,6 +70,7 @@ CommandResponse NFVMonitor::CommandAdd([[maybe_unused]]const bess::pb::NFVMonito
 
 CommandResponse NFVMonitor::CommandClear(const bess::pb::EmptyArg &) {
   per_flow_packet_counter_.clear();
+  per_core_latency_sample_.clear();
   return CommandSuccess();
 }
 

--- a/core/modules/nfv_monitor.cc
+++ b/core/modules/nfv_monitor.cc
@@ -58,7 +58,7 @@ CommandResponse NFVMonitor::Init([[maybe_unused]]const bess::pb::NFVMonitorArg &
   }
   LOG(INFO) << "Traffic update period: " << update_traffic_stats_period_ns_;
 
-  per_core_latency_sample_.set_capacity((arg.latency_sample_size()>0)? arg.latency_sample_size():DEFAULT_LATENCY_QUEUE_SIZE);
+  per_core_latency_sample_.set_capacity((arg.latency_sample_buffer_size()>0)? arg.latency_sample_buffer_size():DEFAULT_LATENCY_QUEUE_SIZE);
   per_core_packet_counter_ = 0;
 
   return CommandSuccess();
@@ -192,7 +192,8 @@ CommandResponse NFVMonitor::CommandGetSummary(const bess::pb::EmptyArg &) {
       out_fp << "epoch:" << i << ", core:" << cluster_snapshots_[i].active_core_count << ", rate:" << cluster_snapshots_[i].sum_packet_rate << std::endl;
     }
   }
-  out_fp << "P99 latency:" << GetTailLatency() << std::endl;
+  out_fp << "P50 latency:" << GetTailLatency(50) << std::endl;
+  out_fp << "P99 latency:" << GetTailLatency(99) << std::endl;
 
   out_fp.close();
   return CommandResponse();

--- a/core/modules/nfv_monitor.h
+++ b/core/modules/nfv_monitor.h
@@ -36,15 +36,15 @@ class NFVMonitor final : public Module {
   CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
   CommandResponse CommandGetSummary(const bess::pb::EmptyArg &arg);
 
-  double GetTailLatency() {
-    std::vector<uint64_t> latency_copy_(per_core_latency_sample_.size());
+  double GetTailLatency(uint32_t percentile) {
+    std::vector<uint64_t> latency_copy;
     // Create a copy of the latency buffer
     for (auto it = per_core_latency_sample_.begin(); it != per_core_latency_sample_.end(); it++) {
-      latency_copy_.push_back(*it);
+      latency_copy.push_back(*it);
     }
-    sort(latency_copy_.begin(), latency_copy_.end());
-    size_t idx = ceil(0.99 * latency_copy_.size());
-    return latency_copy_[idx];
+    sort(latency_copy.begin(), latency_copy.end());
+    size_t idx = ceil((percentile/100.0) * latency_copy.size());
+    return latency_copy[idx];
   }
 
  private:

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -976,7 +976,7 @@ message NFVIngressArg {
 message NFVMonitorArg {
   int32 core_id = 1; /// The target CPU core's ID
   int32 update_stats_period_ns = 2; /// Time period of collecting system performance metrics
-  int64 latency_sample_size = 3; // Size of vector to calculate tail latency
+  int64 latency_sample_buffer_size = 3; // Size of vector to calculate tail latency
 }
 
 /**

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -976,6 +976,7 @@ message NFVIngressArg {
 message NFVMonitorArg {
   int32 core_id = 1; /// The target CPU core's ID
   int32 update_stats_period_ns = 2; /// Time period of collecting system performance metrics
+  int64 latency_sample_size = 3; // Size of vector to calculate tail latency
 }
 
 /**

--- a/test_scripts/collect_data.py
+++ b/test_scripts/collect_data.py
@@ -1,0 +1,52 @@
+import os
+from time import sleep
+import subprocess
+import re
+
+run_time = 10
+reset_time = 5
+pps_sample = [10000,50000,100000]
+pcycle_sample = [20,200,2000]
+num_runs = 3
+
+
+def get_hw_latency(text):
+    pat = re.findall("P99 latency:.*", text)[0]
+    pat = pat.split(':')[-1]
+    return float(pat)
+
+def get_pipline_latency(text):
+    pat = re.findall("percentile_values_ns:.*", text)[0]
+    pat = pat.split(':')[-1]
+    return float(pat)
+
+
+def do_test(i,pps, pcycle):
+    with open("data", 'a') as f:
+        f.write("Run %d --- params: pps=%d pcycle=%d\n"%(i, pps,pcycle))
+    os.system("../bin/bessctl 'run samples/hw_ts_test BESS_PKT_SIZE=200,BESS_PKT_CYCLE="+str(pcycle)+",BESS_PKT_RATE="+str(pps)+"'")
+    sleep(reset_time)
+    os.system("../bin/bessctl 'command module nfv_monitor clear EmptyArg'")
+    os.system("../bin/bessctl 'command module measure0 clear EmptyArg'")
+    sleep(run_time)
+    os.system("../bin/bessctl 'command module nfv_monitor get_summary EmptyArg'")
+    os.system("../bin/bessctl 'command module measure0 get_summary MeasureCommandGetSummaryArg {\"latency_percentiles\":[99]}' > output")
+    (out,err) = subprocess.Popen(["cat", "../stats.txt"], stdout=subprocess.PIPE).communicate()
+    hw_latency = get_hw_latency(out)
+    (out,err) = subprocess.Popen(["cat", "output"], stdout=subprocess.PIPE).communicate()
+    latency = get_pipline_latency(out)
+    with open("data",'a') as f:
+        f.write("%d,%d\n"%(hw_latency, latency))
+    print(hw_latency, latency)
+
+def run_test():
+    for pps in pps_sample:
+        for pcycle in pcycle_sample:
+            for i in range(num_runs):
+                do_test(i,pps,pcycle)
+            
+
+def clear_system():
+    os.system("rm -f ../stats.txt data output")
+clear_system()
+run_test()

--- a/test_scripts/collect_data.py
+++ b/test_scripts/collect_data.py
@@ -1,3 +1,23 @@
+'''
+python collect_data.py
+
+This script is used to run tests and collect data.
+It has been designed to run the following pipeline:
+fg-> timestamp -> port_out
+port_in -> nfv_monitor -> bypass -> measure -> sink
+
+The port out is looped back to port in. The entire pipeline
+is present in hw_ts_test.bess file.
+
+It collects stats from nfv_monitor and the measure module.
+This data gets written to a file named "data"
+
+This script can be used as a template to write more automations
+and collect test data
+
+The script uses bessctl to interact with bessd and collect data
+by writing the output to files.
+'''
 import os
 from time import sleep
 import subprocess
@@ -6,22 +26,29 @@ import re
 run_time = 10
 reset_time = 5
 pps_sample = [10000,50000,100000]
-pcycle_sample = [20,200,2000]
+pcycle_sample = [200,2000, 20000, 200000]
 num_runs = 3
 
 
 def get_hw_latency(text):
+    latency = []
+    pat = re.findall("P50 latency:.*", text)[0]
+    pat = pat.split(':')[-1]
+    latency.append(float(pat))
     pat = re.findall("P99 latency:.*", text)[0]
     pat = pat.split(':')[-1]
-    return float(pat)
+    latency.append(float(pat))
+    return latency
 
 def get_pipline_latency(text):
-    pat = re.findall("percentile_values_ns:.*", text)[0]
-    pat = pat.split(':')[-1]
-    return float(pat)
+    pat = re.findall("percentile_values_ns:.*", text)
+    latency = [float(x.split(':')[-1]) for x in pat]
+    return latency
 
 
 def do_test(i,pps, pcycle):
+    os.system("../bin/bessctl daemon stop")
+    os.system("../bin/bessctl daemon start")
     with open("data", 'a') as f:
         f.write("Run %d --- params: pps=%d pcycle=%d\n"%(i, pps,pcycle))
     os.system("../bin/bessctl 'run samples/hw_ts_test BESS_PKT_SIZE=200,BESS_PKT_CYCLE="+str(pcycle)+",BESS_PKT_RATE="+str(pps)+"'")
@@ -30,16 +57,18 @@ def do_test(i,pps, pcycle):
     os.system("../bin/bessctl 'command module measure0 clear EmptyArg'")
     sleep(run_time)
     os.system("../bin/bessctl 'command module nfv_monitor get_summary EmptyArg'")
-    os.system("../bin/bessctl 'command module measure0 get_summary MeasureCommandGetSummaryArg {\"latency_percentiles\":[99]}' > output")
-    (out,err) = subprocess.Popen(["cat", "../stats.txt"], stdout=subprocess.PIPE).communicate()
+    os.system("../bin/bessctl 'command module measure0 get_summary MeasureCommandGetSummaryArg {\"latency_percentiles\":[50,99]}' > output")
+    (out,err) = subprocess.Popen(["cat", "stats.txt"], stdout=subprocess.PIPE).communicate()
     hw_latency = get_hw_latency(out)
     (out,err) = subprocess.Popen(["cat", "output"], stdout=subprocess.PIPE).communicate()
     latency = get_pipline_latency(out)
     with open("data",'a') as f:
-        f.write("%d,%d\n"%(hw_latency, latency))
+        f.write("%d,%d,%d,%d\n"%(hw_latency[0], latency[0], hw_latency[1], latency[1]))
     print(hw_latency, latency)
 
 def run_test():
+    with open("data",'a') as f:
+        f.write("p50_hw, p50_measure, p99_hw, p99_measure\n")
     for pps in pps_sample:
         for pcycle in pcycle_sample:
             for i in range(num_runs):
@@ -47,6 +76,6 @@ def run_test():
             
 
 def clear_system():
-    os.system("rm -f ../stats.txt data output")
+    os.system("rm -f stats.txt data output")
 clear_system()
 run_test()


### PR DESCRIPTION
This change requires the installation of libboost-all-dev.

Changed per_core_latency_sample_ to a circular buffer to maintain a sliding window of samples.
Add functionalities to clear data samples.