### PR TITLE
manage unassigned software queues

### DIFF
--- a/bessctl/conf/samples/chain4_long_term_test.bess
+++ b/bessctl/conf/samples/chain4_long_term_test.bess
@@ -40,7 +40,6 @@ core_addrs = [
 ]
 core_cnt=len(core_addrs)
 pcie1, offset1="af:00.0", 7
-port_out::PMDPort(pci=pcie1, num_out_q=1, bench_rss=False)
 rcore_cnt=4
 
 total_core_cnt = core_cnt + rcore_cnt

--- a/bessctl/conf/samples/chain4_long_term_test.bess
+++ b/bessctl/conf/samples/chain4_long_term_test.bess
@@ -30,12 +30,18 @@ core_addrs = [
     {'l2_port': 2, 'l2_mac': '2e:c7:8b:7b:8d:a8'},
     {'l2_port': 3, 'l2_mac': '2a:9d:fd:13:15:01'},
     {'l2_port': 4, 'l2_mac': '32:a5:0f:e0:04:0b'},
-#    {'l2_port': 5, 'l2_mac': '06:8a:62:fb:51:51'},
-#    {'l2_port': 6, 'l2_mac': 'ce:2e:14:c4:a0:cb'},
-#    {'l2_port': 7, 'l2_mac': '6e:af:01:7a:93:6f'},
+    {'l2_port': 5, 'l2_mac': '06:8a:62:fb:51:51'},
+    {'l2_port': 6, 'l2_mac': 'ce:2e:14:c4:a0:cb'},
+    {'l2_port': 7, 'l2_mac': '6e:af:01:7a:93:6f'},
 #    {'l2_port': 8, 'l2_mac': '00:af:01:7a:93:6f'},
 ]
 core_cnt=len(core_addrs)
+pcie1, offset1="af:00.0", 7
+port_out::PMDPort(pci=pcie1, num_out_q=1, bench_rss=False)
+rcore_cnt=4
+
+total_core_cnt = core_cnt + rcore_cnt
+print("normal core:%d, reserved core:%d" %(core_cnt, rcore_cnt))
 
 acl_rules = []
 for i in range(acl_cnt / 50):
@@ -49,7 +55,12 @@ for i in range(lb_cnt / 20):
         nat_hosts.append({'endpoint': '192.168.%d.%d' %(i/255, i%255)})
 
 # Module
-port0::PMDPort(pci=pcie0, num_inc_q=core_cnt, num_out_q=core_cnt, bench_rss=False)
+port0::PMDPort(pci=pcie0, num_inc_q=core_cnt, num_out_q=total_core_cnt, bench_rss=False)
+# Core
+nfvctrl::NFVCtrl(core_addrs=core_addrs, slo_ns=slo, port=port0)
+bess.add_worker(wid=nfvctrl_core, core=nfvctrl_core)
+nfvctrl.attach_task(wid=nfvctrl_core)
+
 pinc0 = {}
 pout0 = {}
 fw = {}
@@ -93,10 +104,17 @@ for i in range(len(core_addrs)):
 for i in range(core_cnt):
     pinc0[i].set_burst(burst=burst_size)
 
-# Core
-nfvctrl::NFVCtrl(core_addrs=core_addrs, slo_ns=slo, port=port0)
-bess.add_worker(wid=nfvctrl_core, core=nfvctrl_core)
-nfvctrl.attach_task(wid=nfvctrl_core)
+for i in range(rcore_cnt):
+    rcore_id = core_cnt + i
+    pinc0[rcore_id] = NFVRCore(core_id=rcore_id)
+    pout0[rcore_id] = QueueOut(port=port0, qid=rcore_id)
+    pinc0[rcore_id] -> pout0[rcore_id]
+
+for i in range(rcore_cnt):
+    bess.add_worker(wid=i+offset0+core_cnt, core=i+offset0+core_cnt)
+    rcore_id = core_cnt + i
+    pinc0[rcore_id].attach_task(wid=i+offset0+core_cnt)
+
 
 for i in range(core_cnt):
     bess.add_worker(wid=i+offset0, core=i+offset0)
@@ -126,13 +144,13 @@ fg0::FlowGen(
     arrival='uniform', duration='uniform', quick_rampup=True,
     port_src_range=255, port_dst_range=255,
 )
-pcie1, offset1="af:00.0", 7
-port_out::PMDPort(pci=pcie1, num_out_q=1, bench_rss=False)
+
 pgen = QueueOut(port=port_out, qid=0)
 
 fg0 -> pgen
 
-bess.add_worker(wid=7, core=7)
-fg0.attach_task(wid=7)
+gen_core = 13
+bess.add_worker(wid=gen_core, core=gen_core)
+fg0.attach_task(wid=gen_core)
 
 bess.resume_all()

--- a/core/modules/nfv_ctrl.cc
+++ b/core/modules/nfv_ctrl.cc
@@ -431,7 +431,7 @@ struct task_result NFVCtrl::RunTask(Context *, bess::PacketBatch *, void *) {
   }
 
   uint64_t curr_ts_ns = tsc_to_ns(rdtsc());
-  if (false &&curr_ts_ns - long_epoch_last_update_time_ > long_epoch_update_period_) {
+  if (curr_ts_ns - long_epoch_last_update_time_ > long_epoch_update_period_) {
     UpdateFlowAssignment();
     long_epoch_last_update_time_ = curr_ts_ns;
   }

--- a/core/modules/nfv_ctrl.cc
+++ b/core/modules/nfv_ctrl.cc
@@ -101,10 +101,10 @@ void NFVCtrl::ReleaseSwQ(int q_id) {
 
 void DumpQueueBatch(struct llring* q, bess::PacketBatch *batch) {
   uint32_t cnt = 0;
-  uint32_t total_freed = 0;
+  batch->clear();
   while ((cnt = llring_sc_dequeue_burst(q, (void **)batch->pkts(), batch->kMaxBurst))!=0) {
-    bess::Packet::Free(batch->pkts() + total_freed, cnt);
-    total_freed += cnt;
+    bess::Packet::Free(batch->pkts(), cnt);
+    batch->clear();
   }
 }
 

--- a/core/modules/nfv_ctrl.cc
+++ b/core/modules/nfv_ctrl.cc
@@ -135,7 +135,6 @@ int NFVCtrl::NotifyRCoreToWork(cpu_core_t core_id, int q_id) {
   // No RCores found. System Overloaded! Drop packets
   sw_q_to_drop_.push_back(bess::ctrl::sw_q[q_id]);
   bess::ctrl::sw_q_state[q_id]->down_core_id = DEFAULT_NFVCTRL_CORE_ID;
-  LOG(INFO) << "Queue " << q_id << " assigned to nfv_ctrl";
   return 3;
 }
 
@@ -154,8 +153,7 @@ int NFVCtrl::NotifyRCoreToRest(cpu_core_t core_id, int q_id) {
   cpu_core_t down = bess::ctrl::sw_q_state[q_id]->down_core_id;
   if (down == DEFAULT_NFVCTRL_CORE_ID) {
     // Queue has been assigned to nfv_ctrl for dumping.
-   LOG(INFO) << "Queue " << q_id << " assigned to nfv_ctrl released";
-   std::vector<struct llring*>::iterator it = std::find(sw_q_to_drop_.begin(), sw_q_to_drop_.end(), bess::ctrl::sw_q[q_id]);
+    std::vector<struct llring*>::iterator it = std::find(sw_q_to_drop_.begin(), sw_q_to_drop_.end(), bess::ctrl::sw_q[q_id]);
     assert (it != sw_q_to_drop_.end());
     sw_q_to_drop_.erase(it);
   } else {

--- a/core/modules/nfv_ctrl.cc
+++ b/core/modules/nfv_ctrl.cc
@@ -111,6 +111,16 @@ void NFVCtrl::ReleaseSwQ(int q_id) {
   bess::ctrl::sw_q_state[q_id]->up_core_id = DEFAULT_INVALID_CORE_ID;
 }
 
+void DumpQueueBatch(struct llring* q) {
+  bess::PacketBatch *batch = reinterpret_cast<bess::PacketBatch *>
+          (std::aligned_alloc(alignof(bess::PacketBatch), sizeof(bess::PacketBatch)));
+  uint32_t cnt = 0;
+  uint32_t total_freed = 0;
+  while ((cnt = llring_sc_dequeue_burst(q, (void **)batch->pkts(), batch->kMaxBurst))!=0) {
+    bess::Packet::Free(batch->pkts() + total_freed, cnt);
+    total_freed += cnt;
+  }
+}
 bool NFVCtrl::NotifyRCoreToWork(cpu_core_t core_id, int q_id) {
   const std::lock_guard<std::mutex> lock(sw_q_mtx_);
 
@@ -135,6 +145,10 @@ bool NFVCtrl::NotifyRCoreToWork(cpu_core_t core_id, int q_id) {
     bess::ctrl::sw_q_state[q_id]->down_core_id = i;
     return true;
   }
+  // No RCores found. System Overloaded! Drop packets
+  sw_q_to_drop_.push_back(bess::ctrl::sw_q[q_id]);
+  bess::ctrl::sw_q_state[q_id]->down_core_id = DEFAULT_NFVCTRL_CORE_ID;
+  LOG(INFO) << "Queue " << q_id << " assigned to nfv_ctrl";
   return false;
 }
 
@@ -151,8 +165,16 @@ void NFVCtrl::NotifyRCoreToRest(cpu_core_t core_id, int q_id) {
   }
 
   cpu_core_t down = bess::ctrl::sw_q_state[q_id]->down_core_id;
-  bess::ctrl::nfv_rcores[down]->RemoveQueue(bess::ctrl::sw_q[q_id]);
-  bess::ctrl::rcore_state[down] = true; // reset so that it can be assigned later
+  if (down == DEFAULT_NFVCTRL_CORE_ID) {
+    // Queue has been assigned to nfv_ctrl for dumping.
+   LOG(INFO) << "Queue " << q_id << " assigned to nfv_ctrl released";
+   std::vector<struct llring*>::iterator it = std::find(sw_q_to_drop_.begin(), sw_q_to_drop_.end(), bess::ctrl::sw_q[q_id]);
+    assert (it != sw_q_to_drop_.end());
+    sw_q_to_drop_.erase(it);
+  } else {
+   bess::ctrl::nfv_rcores[down]->RemoveQueue(bess::ctrl::sw_q[q_id]);
+   bess::ctrl::rcore_state[down] = true; // reset so that it can be assigned later
+  }
   bess::ctrl::sw_q_state[q_id]->down_core_id = DEFAULT_INVALID_CORE_ID;
 }
 
@@ -409,9 +431,14 @@ struct task_result NFVCtrl::RunTask(Context *, bess::PacketBatch *, void *) {
   }
 
   uint64_t curr_ts_ns = tsc_to_ns(rdtsc());
-  if (curr_ts_ns - long_epoch_last_update_time_ > long_epoch_update_period_) {
+  if (false &&curr_ts_ns - long_epoch_last_update_time_ > long_epoch_update_period_) {
     UpdateFlowAssignment();
     long_epoch_last_update_time_ = curr_ts_ns;
+  }
+  if (unlikely(sw_q_to_drop_.size() > 0)) {
+    for(uint32_t i = 0; i < sw_q_to_drop_.size(); i++) {
+      DumpQueueBatch(sw_q_to_drop_[i]);
+    }
   }
 
   return {.block = false, .packets = 0, .bits = 0};

--- a/core/modules/nfv_ctrl.cc
+++ b/core/modules/nfv_ctrl.cc
@@ -433,7 +433,7 @@ struct task_result NFVCtrl::RunTask(Context *, bess::PacketBatch *, void *) {
   }
 
   uint64_t curr_ts_ns = tsc_to_ns(rdtsc());
-  if (false &&curr_ts_ns - long_epoch_last_update_time_ > long_epoch_update_period_) {
+  if (curr_ts_ns - long_epoch_last_update_time_ > long_epoch_update_period_) {
     UpdateFlowAssignment();
     long_epoch_last_update_time_ = curr_ts_ns;
   }

--- a/core/modules/nfv_ctrl.h
+++ b/core/modules/nfv_ctrl.h
@@ -72,6 +72,7 @@ class NFVCtrl final : public Module {
 
   // The lock for maintaining a pool of software queues
   mutable std::mutex sw_q_mtx_;
+  std::vector<struct llring*> sw_q_to_drop_;
 
   uint64_t curr_ts_ns_;
 };

--- a/core/utils/cpu_core.h
+++ b/core/utils/cpu_core.h
@@ -7,6 +7,7 @@
 
 // Valid Core ID range [0, 63]
 #define DEFAULT_INVALID_CORE_ID 64
+#define DEFAULT_NFVCTRL_CORE_ID 63 
 
 typedef uint16_t cpu_core_t;
 


### PR DESCRIPTION
SW queues for which reserved core are not found gets assigned to nfv_ctrl. nfv_ctrl clears the queue by freeing up the packets.